### PR TITLE
Localize new task state

### DIFF
--- a/src/actions/tasks.tsx
+++ b/src/actions/tasks.tsx
@@ -3,7 +3,6 @@ import { createAction } from 'retreon';
 import * as tasks from '../effects/tasks';
 import { TaskView } from '../reducers/tasks';
 
-export const updateTitle = createAction<string>('tasks/update-title');
 export const create = createAction('tasks/create', tasks.createTaskMetadata);
 export const remove = createAction<string>('tasks/remove');
 export const markCompleted = createAction<string>('tasks/mark-completed');

--- a/src/components/TaskInput.tsx
+++ b/src/components/TaskInput.tsx
@@ -6,6 +6,8 @@ import { MdExpandMore } from 'react-icons/md';
 import * as tasks from '../actions/tasks';
 import { Button } from './common';
 
+const PURE_WHITESPACE_REGEX = /^\s*$/;
+
 export class TaskInput extends React.Component<Props, State> {
   state = {
     title: '',
@@ -37,8 +39,10 @@ export class TaskInput extends React.Component<Props, State> {
     event.stopPropagation();
     event.preventDefault();
 
-    this.props.createTask(this.state.title);
-    this.setState({ title: '' });
+    if (!PURE_WHITESPACE_REGEX.test(this.state.title)) {
+      this.props.createTask(this.state.title);
+      this.setState({ title: '' });
+    }
   };
 }
 

--- a/src/components/TaskInput.tsx
+++ b/src/components/TaskInput.tsx
@@ -3,18 +3,14 @@ import styled from 'styled-components';
 import { connect } from 'react-redux';
 import { MdExpandMore } from 'react-icons/md';
 
-import { RootState } from '../reducers/tasks';
 import * as tasks from '../actions/tasks';
 import { Button } from './common';
 
-interface Props {
-  title: string;
-  updateTitle: typeof tasks.updateTitle;
-  createTask: typeof tasks.create;
-  toggleTaskCompletion: typeof tasks.toggleCompletion;
-}
+export class TaskInput extends React.Component<Props, State> {
+  state = {
+    title: '',
+  };
 
-export class TaskInput extends React.Component<Props> {
   render() {
     return (
       <Container data-test-id="new-todo-form" onSubmit={this.appendTodo}>
@@ -24,7 +20,7 @@ export class TaskInput extends React.Component<Props> {
 
         <Input
           data-test-id="new-todo-input"
-          value={this.props.title}
+          value={this.state.title}
           autoFocus
           placeholder="What needs to be done?"
           onInput={this.updateInputContent}
@@ -34,14 +30,25 @@ export class TaskInput extends React.Component<Props> {
   }
 
   updateInputContent = (event: React.SyntheticEvent<HTMLInputElement>) => {
-    this.props.updateTitle(event.currentTarget.value);
+    this.setState({ title: event.currentTarget.value });
   };
 
   appendTodo = (event: React.SyntheticEvent<HTMLFormElement>) => {
     event.stopPropagation();
     event.preventDefault();
-    this.props.createTask();
+
+    this.props.createTask(this.state.title);
+    this.setState({ title: '' });
   };
+}
+
+interface Props {
+  createTask: typeof tasks.create;
+  toggleTaskCompletion: typeof tasks.toggleCompletion;
+}
+
+interface State {
+  title: string;
 }
 
 const Container = styled.form`
@@ -80,14 +87,9 @@ const Input = styled.input`
   }
 `;
 
-const mapStateToProps = (state: RootState) => ({
-  title: state.newTaskTitle,
-});
-
 const mapDispatchToProps = {
-  updateTitle: tasks.updateTitle,
   createTask: tasks.create,
   toggleTaskCompletion: tasks.toggleCompletion,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(TaskInput);
+export default connect(null, mapDispatchToProps)(TaskInput);

--- a/src/components/__tests__/TaskInput.test.tsx
+++ b/src/components/__tests__/TaskInput.test.tsx
@@ -19,35 +19,43 @@ describe('TaskInput', () => {
       return output.find({ 'data-test-id': id });
     }
 
+    const simulate = {
+      input(input: string) {
+        findByTestId('new-todo-input').simulate('input', {
+          currentTarget: { value: input },
+        });
+      },
+
+      submit() {
+        findByTestId('new-todo-form').simulate('submit', new Event('submit'));
+      },
+    };
+
     return {
       output,
       props,
       findByTestId,
+      simulate,
     };
   }
 
-  it('shows the new todo title', () => {
-    const { findByTestId, props } = setup();
-
-    expect(findByTestId('new-todo-input').prop('value')).toBe(props.title);
-  });
-
   it('updates the title when it changes', () => {
-    const { findByTestId, props } = setup();
+    const { simulate, findByTestId } = setup();
 
     const title = 'release the kraken!';
-    findByTestId('new-todo-input').simulate('input', {
-      currentTarget: { value: title },
-    });
+    simulate.input(title);
 
-    expect(props.updateTitle).toHaveBeenCalledWith(title);
+    expect(findByTestId('new-todo-input').prop('value')).toBe(title);
   });
 
-  it('can submit the new todo', () => {
-    const { findByTestId, props } = setup({ title: 'call mum' });
+  it('creates the new task', () => {
+    const { props, simulate, findByTestId } = setup();
 
-    findByTestId('new-todo-form').simulate('submit', new Event('submit'));
+    const title = 'call mum';
+    simulate.input(title);
+    simulate.submit();
 
-    expect(props.createTask).toHaveBeenCalled();
+    expect(props.createTask).toHaveBeenCalledWith(title);
+    expect(findByTestId('new-todo-input').prop('value')).toBe('');
   });
 });

--- a/src/components/__tests__/TaskInput.test.tsx
+++ b/src/components/__tests__/TaskInput.test.tsx
@@ -58,4 +58,13 @@ describe('TaskInput', () => {
     expect(props.createTask).toHaveBeenCalledWith(title);
     expect(findByTestId('new-todo-input').prop('value')).toBe('');
   });
+
+  it('does not create a task if there is only whitespace', () => {
+    const { props, simulate } = setup();
+
+    simulate.input('  \t\n\t  ');
+    simulate.submit();
+
+    expect(props.createTask).not.toHaveBeenCalled();
+  });
 });

--- a/src/effects/__tests__/tasks.test.tsx
+++ b/src/effects/__tests__/tasks.test.tsx
@@ -8,9 +8,11 @@ jest.setSystemTime(CURRENT_TIME);
 describe('Task effects', () => {
   describe('create', () => {
     it('assigns an ID and creation date to the task', () => {
-      const task = tasks.createTaskMetadata();
+      const title = 'mow the astroturf';
+      const task = tasks.createTaskMetadata(title);
 
       expect(task).toEqual({
+        title,
         id: expect.any(String),
         creationDate: CURRENT_TIME.toISOString(),
       });

--- a/src/effects/tasks.tsx
+++ b/src/effects/tasks.tsx
@@ -1,7 +1,8 @@
 import { v4 as uuid } from 'uuid';
 
-export function createTaskMetadata() {
+export function createTaskMetadata(title: string) {
   return {
+    title,
     creationDate: new Date().toISOString(),
     id: uuid(),
   };

--- a/src/reducers/__tests__/tasks.test.tsx
+++ b/src/reducers/__tests__/tasks.test.tsx
@@ -12,30 +12,20 @@ describe('Todo list reducer', () => {
   const MOCK_ID = '<random-id>';
 
   beforeEach(() => {
-    mockedEffects.createTaskMetadata.mockReturnValue({
+    mockedEffects.createTaskMetadata.mockImplementation((title) => ({
+      title,
       creationDate: MOCK_CREATION_DATE,
       id: MOCK_ID,
-    });
-  });
-
-  it('updates the new todo title when instructed', () => {
-    const store = initializeStore();
-
-    const title = 'pet the otters';
-    store.dispatch(tasks.updateTitle(title));
-
-    expect(store.getState()).toHaveProperty('newTaskTitle', title);
+    }));
   });
 
   it('appends the new todo into the list of tasks', () => {
     const store = initializeStore();
 
     const title = 'beat AlphaGo 52-2';
-    store.dispatch(tasks.updateTitle(title));
-    store.dispatch(tasks.create());
+    store.dispatch(tasks.create(title));
 
     expect(store.getState()).toMatchObject({
-      newTaskTitle: '',
       tasks: {
         [MOCK_ID]: {
           title,
@@ -48,9 +38,7 @@ describe('Todo list reducer', () => {
 
   it('can remove a task when instructed', () => {
     const store = initializeStore();
-
-    store.dispatch(tasks.updateTitle('meet Ghandi'));
-    store.dispatch(tasks.create());
+    store.dispatch(tasks.create('meet Ghandi'));
 
     const [id] = Object.keys(store.getState().tasks);
     store.dispatch(tasks.remove(id));
@@ -60,9 +48,7 @@ describe('Todo list reducer', () => {
 
   it('can toggle completion', () => {
     const store = initializeStore();
-
-    store.dispatch(tasks.updateTitle('bake a pie'));
-    store.dispatch(tasks.create());
+    store.dispatch(tasks.create('bake a pie'));
 
     const [id] = Object.keys(store.getState().tasks);
     store.dispatch(tasks.markCompleted(id));
@@ -75,8 +61,7 @@ describe('Todo list reducer', () => {
   it('clears completed tasks', () => {
     const store = initializeStore();
 
-    store.dispatch(tasks.updateTitle('sleep more'));
-    store.dispatch(tasks.create());
+    store.dispatch(tasks.create('sleep more'));
 
     const [id] = Object.keys(store.getState().tasks);
     store.dispatch(tasks.markCompleted(id));
@@ -95,8 +80,7 @@ describe('Todo list reducer', () => {
   it('toggles task completion', () => {
     const store = initializeStore();
 
-    store.dispatch(tasks.updateTitle('change name to Gill Bates'));
-    store.dispatch(tasks.create());
+    store.dispatch(tasks.create('change name to Gill Bates'));
 
     store.dispatch(tasks.toggleCompletion());
     expect(Object.values(store.getState().tasks)).toMatchObject([

--- a/src/reducers/tasks.tsx
+++ b/src/reducers/tasks.tsx
@@ -4,7 +4,6 @@ import * as tasks from '../actions/tasks';
 
 export interface RootState {
   view: TaskView;
-  newTaskTitle: string;
   tasks: {
     [taskId: string]: Task;
   };
@@ -24,23 +23,16 @@ export interface Task {
 
 export const initialState: RootState = {
   view: TaskView.All,
-  newTaskTitle: '',
   tasks: {},
 };
 
 export default createReducer(initialState, (handleAction) => [
-  handleAction(tasks.updateTitle, (state, title) => {
-    state.newTaskTitle = title;
-  }),
-
-  handleAction(tasks.create, (state, { id, creationDate }) => {
+  handleAction(tasks.create, (state, { id, creationDate, title }) => {
     state.tasks[id] = {
-      title: state.newTaskTitle,
+      title,
       completed: false,
       creationDate,
     };
-
-    state.newTaskTitle = '';
   }),
 
   handleAction(tasks.remove, (state, id) => {


### PR DESCRIPTION
Gist: `state.newTaskTitle` moved into component state, `tasks.create(...)` takes a title now, and whitespace isn't a valid title anymore.