### PR TITLE
Allow task edits

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.8",
     "@types/react-redux": "^7.1.11",
+    "freeform-input": "^0.2.0",
     "invariant": "^2.2.4",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/src/actions/tasks.tsx
+++ b/src/actions/tasks.tsx
@@ -10,3 +10,7 @@ export const markIncomplete = createAction<string>('tasks/mark-incomplete');
 export const clearCompleted = createAction('tasks/clear-completed');
 export const changeView = createAction<TaskView>('tasks/change-view');
 export const toggleCompletion = createAction('tasks/toggle-completion');
+export const startEditing = createAction<string>('tasks/start-editing');
+export const finishEditing = createAction<{ id: string; newTitle: string }>(
+  'tasks/finish-editing',
+);

--- a/src/reducers/__tests__/tasks.test.tsx
+++ b/src/reducers/__tests__/tasks.test.tsx
@@ -30,6 +30,7 @@ describe('Todo list reducer', () => {
         [MOCK_ID]: {
           title,
           completed: false,
+          editing: false,
           creationDate: MOCK_CREATION_DATE,
         },
       },
@@ -40,8 +41,7 @@ describe('Todo list reducer', () => {
     const store = initializeStore();
     store.dispatch(tasks.create('meet Ghandi'));
 
-    const [id] = Object.keys(store.getState().tasks);
-    store.dispatch(tasks.remove(id));
+    store.dispatch(tasks.remove(MOCK_ID));
 
     expect(store.getState().tasks).toEqual({});
   });
@@ -50,21 +50,18 @@ describe('Todo list reducer', () => {
     const store = initializeStore();
     store.dispatch(tasks.create('bake a pie'));
 
-    const [id] = Object.keys(store.getState().tasks);
-    store.dispatch(tasks.markCompleted(id));
-    expect(store.getState().tasks[id]).toHaveProperty('completed', true);
+    store.dispatch(tasks.markCompleted(MOCK_ID));
+    expect(store.getState().tasks[MOCK_ID]).toHaveProperty('completed', true);
 
-    store.dispatch(tasks.markIncomplete(id));
-    expect(store.getState().tasks[id]).toHaveProperty('completed', false);
+    store.dispatch(tasks.markIncomplete(MOCK_ID));
+    expect(store.getState().tasks[MOCK_ID]).toHaveProperty('completed', false);
   });
 
   it('clears completed tasks', () => {
     const store = initializeStore();
 
     store.dispatch(tasks.create('sleep more'));
-
-    const [id] = Object.keys(store.getState().tasks);
-    store.dispatch(tasks.markCompleted(id));
+    store.dispatch(tasks.markCompleted(MOCK_ID));
     store.dispatch(tasks.clearCompleted());
 
     expect(store.getState().tasks).toEqual({});
@@ -91,5 +88,20 @@ describe('Todo list reducer', () => {
     expect(Object.values(store.getState().tasks)).toMatchObject([
       { completed: false },
     ]);
+  });
+
+  it('allows editing task titles', () => {
+    const store = initializeStore();
+
+    store.dispatch(tasks.create('pet the otters'));
+    store.dispatch(tasks.startEditing(MOCK_ID));
+
+    expect(store.getState().tasks[MOCK_ID]).toHaveProperty('editing', true);
+
+    store.dispatch(tasks.finishEditing({ id: MOCK_ID, newTitle: 'run' }));
+    expect(store.getState().tasks[MOCK_ID]).toMatchObject({
+      editing: false,
+      title: 'run',
+    });
   });
 });

--- a/src/reducers/tasks.tsx
+++ b/src/reducers/tasks.tsx
@@ -18,6 +18,7 @@ export enum TaskView {
 export interface Task {
   title: string;
   completed: boolean;
+  editing: boolean;
   creationDate: string; // ISO-8601
 }
 
@@ -31,6 +32,7 @@ export default createReducer(initialState, (handleAction) => [
     state.tasks[id] = {
       title,
       completed: false,
+      editing: false,
       creationDate,
     };
   }),
@@ -64,5 +66,14 @@ export default createReducer(initialState, (handleAction) => [
     tasks.forEach((task) => {
       task.completed = hasIncompleteTask;
     });
+  }),
+
+  handleAction(tasks.startEditing, (state, taskId) => {
+    state.tasks[taskId].editing = true;
+  }),
+
+  handleAction(tasks.finishEditing, (state, { id, newTitle }) => {
+    state.tasks[id].editing = false;
+    state.tasks[id].title = newTitle;
   }),
 ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5234,6 +5234,11 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+freeform-input@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/freeform-input/-/freeform-input-0.2.0.tgz#10442b97a19ebc56df048e3826fffa10d3525860"
+  integrity sha512-bB+4cOywn7Kv5bOdq+wvTp9Evy+ZVTaLhzYPx3GwPZkdQsraS2YWH9aolHEox+yYnh/MCY8dbWZErZZ2u2AhVw==
+
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"


### PR DESCRIPTION
There's a note at the bottom of TodoMVC apps that reads "Double-click to edit a todo". I added the note, but forgot the feature.

This PR implements task edits.