### PR TITLE
Hide toolbar if no tasks exist

### DIFF
--- a/cypress/integration/todomvc.test.ts
+++ b/cypress/integration/todomvc.test.ts
@@ -9,6 +9,11 @@ describe('TodoMVC', () => {
     cy.get('[data-test=task-title]').should('have.text', 'Use Cypress');
   });
 
+  it('hides the toolbar when no tasks exist', () => {
+    cy.get('[data-test=task-list]').should('not.exist');
+    cy.get('[data-test=task-list-toolbar]').should('not.exist');
+  });
+
   it('deletes tasks when you click the delete button', () => {
     cy.get('[data-test=new-task-input]').type('Adopt a turtle{enter}');
     cy.get('[data-test=task-delete-button]').click();

--- a/src/components/ListView.tsx
+++ b/src/components/ListView.tsx
@@ -10,6 +10,7 @@ import ListFilter from './ListFilter';
 
 interface Props {
   incompleteTasks: number;
+  hasTasks: boolean;
   taskIds: Array<string>; // List of task IDs.
   clearCompletedTasks: typeof tasks.clearCompleted;
 }
@@ -18,18 +19,19 @@ export function ListView({
   incompleteTasks,
   taskIds,
   clearCompletedTasks,
+  hasTasks,
 }: Props) {
   const pluralizedEntity = incompleteTasks === 1 ? 'item' : 'items';
 
-  return (
+  return hasTasks === false ? null : (
     <Container>
-      <TaskList>
+      <TaskList data-test="task-list">
         {taskIds.map((taskId) => (
           <Task id={taskId} key={taskId} />
         ))}
       </TaskList>
 
-      <Controls>
+      <Controls data-test="task-list-toolbar">
         <RemainingTasks>
           {incompleteTasks} {pluralizedEntity} left
         </RemainingTasks>
@@ -91,6 +93,7 @@ export const mapStateToProps = (state: RootState) => {
 
   return {
     incompleteTasks: tasks.filter((task) => !task.completed).length,
+    hasTasks: tasks.length > 0,
     taskIds: Object.entries(state.tasks)
       .sort(([, t1], [, t2]) => {
         return (

--- a/src/components/__tests__/ListView.test.tsx
+++ b/src/components/__tests__/ListView.test.tsx
@@ -10,6 +10,8 @@ describe('ListView', () => {
     const props = {
       taskIds: ['task-id-1', 'task-id-2'],
       incompleteTasks: 5,
+      hasTasks: true,
+      clearCompletedTasks: jest.fn(),
       ...overrides,
     };
 
@@ -36,10 +38,16 @@ describe('ListView', () => {
   });
 
   describe('mapStateToProps', () => {
-    it('returns the task count', () => {
+    it('returns props', () => {
       const state = mapStateToProps(initialState);
 
-      expect(state).toHaveProperty('incompleteTasks', 0);
+      expect(state).toMatchInlineSnapshot(`
+        Object {
+          "hasTasks": false,
+          "incompleteTasks": 0,
+          "taskIds": Array [],
+        }
+      `);
     });
 
     it('grabs the list of tasks', () => {
@@ -48,12 +56,14 @@ describe('ListView', () => {
         tasks: {
           second: {
             title: 'age another year',
-            completed: true,
+            completed: false,
+            editing: true,
             creationDate: '2005',
           },
           first: {
             title: 'conquer the world',
             completed: false,
+            editing: false,
             creationDate: '2000',
           },
         },
@@ -71,11 +81,13 @@ describe('ListView', () => {
           first: {
             title: 'learn to pilot a helicopter',
             completed: false,
+            editing: false,
             creationDate: '2020',
           },
           second: {
             title: 'write yet another JS framework',
             completed: true,
+            editing: false,
             creationDate: '2019',
           },
         },


### PR DESCRIPTION
I originally missed this behavior, then while reading through the test
set for the official TodoMVC repository, I noticed a case I didn't
implement: the toolbar and task list should be completely hidden if no
tasks exist.

<img width="674" alt="Screen Shot 2020-11-26 at 3 33 19 PM" src="https://user-images.githubusercontent.com/10053423/100397062-b6cbb680-2ffc-11eb-9ff7-defed5baa576.png">